### PR TITLE
Time Lag Fix

### DIFF
--- a/ROMSPath.f90
+++ b/ROMSPath.f90
@@ -489,7 +489,7 @@ contains
 	     t_b  = mod(t_b,3)+1  ! 1 -> 2 -> 3 -> 1
 	     t_c  = mod(t_c,3)+1  ! 2 -> 3 -> 1 -> 2
 	     t_f = mod(t_f,3)+1  ! 3 -> 1 -> 2 -> 3
-		CALL updateHydro(.FALSE.,tstep,t_f)   !do not start updating until 3rd iteration
+		CALL updateHydro(.FALSE.,tstep+1,t_f)   !do not start updating until 3rd iteration
 	  endif
 
 	  


### PR DESCRIPTION
Hello,

I'm just starting using ROMSPath for a project on microplastic transport. Thank you for sharing your code! 

I noticed a time lag error, where the ROMS values that get used to track particles/update particle exposure to temperature and salinity are 1 (ROMS) timestep behind. I made a small change to fix this issue. I found the issue by using made up input data with, for example, temperature = 0,1,2,1,0,... in time (and constant in space).

Hope this is helpful!